### PR TITLE
Add schema refresh and tests

### DIFF
--- a/app/db_schema_index.py
+++ b/app/db_schema_index.py
@@ -1,0 +1,77 @@
+import os
+from typing import Dict, List
+
+# These imports are optional for tests where the modules may not exist
+try:
+    import fdb  # type: ignore
+except ImportError:  # pragma: no cover - fdb might not be installed in test env
+    fdb = None  # type: ignore
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - openai might not be installed in test env
+    OpenAI = None  # type: ignore
+
+DIMENSION = 3072  # dimension for text-embedding-3-large
+
+
+def refresh_schema() -> None:
+    """Refresh schema embeddings stored in the ``schema_index`` collection.
+
+    This function connects to the database defined by ``DATABASE_URL`` using
+    ``fdb``. It introspects ``information_schema`` to gather all tables and
+    their columns, creates one text string per table describing its columns,
+    embeds each string with ``text-embedding-3-large`` and upserts the
+    resulting vectors into the ``schema_index`` table using PGVector.
+    """
+
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        raise ValueError("DATABASE_URL environment variable not set")
+
+    if fdb is None:
+        raise ImportError("fdb module not available")
+    if OpenAI is None:
+        raise ImportError("openai module not available")
+
+    conn = fdb.connect(dsn=db_url)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT table_name, column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+        ORDER BY table_name, ordinal_position
+        """
+    )
+    rows = cur.fetchall()
+
+    tables: Dict[str, List[str]] = {}
+    for table_name, column_name in rows:
+        tables.setdefault(table_name, []).append(column_name)
+
+    table_names = list(tables.keys())
+    texts = [f"{tbl}: {', '.join(cols)}" for tbl, cols in tables.items()]
+
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    embeddings: List[List[float]] = []
+    for i in range(0, len(texts), 100):
+        response = client.embeddings.create(
+            input=texts[i:i + 100],
+            model="text-embedding-3-large",
+        )
+        embeddings.extend([d.embedding for d in response.data])
+
+    for table_name, emb in zip(table_names, embeddings):
+        cur.execute(
+            """
+            INSERT INTO schema_index (table_name, embedding)
+            VALUES (%s, %s)
+            ON CONFLICT (table_name)
+            DO UPDATE SET embedding = EXCLUDED.embedding
+            """,
+            (table_name, emb),
+        )
+    conn.commit()
+    cur.close()
+    conn.close()

--- a/tests/test_db_schema_index.py
+++ b/tests/test_db_schema_index.py
@@ -1,0 +1,126 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import json
+import sqlite3
+from typing import Any
+
+from app import db_schema_index
+
+
+class DummyEmbeddings:
+    def __init__(self, values):
+        self._values = list(values)
+
+    def create(self, input, model):
+        data = []
+        for val in self._values[: len(input)]:
+            data.append(type("Obj", (), {"embedding": val}))
+        self._values = self._values[len(input) :]
+        return type("Resp", (), {"data": data})
+
+
+class DummyOpenAI:
+    def __init__(self, return_values):
+        self.embeddings = DummyEmbeddings(return_values)
+
+
+def setup_sqlite_db(path: str) -> None:
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        'CREATE TABLE "information_schema.columns"(table_schema text, table_name text, column_name text, ordinal_position int)'
+    )
+    cur.executemany(
+        'INSERT INTO "information_schema.columns"(table_schema, table_name, column_name, ordinal_position) VALUES ("public", ?, ?, ?)',
+        [
+            ("users", "id", 1),
+            ("users", "name", 2),
+            ("orders", "id", 1),
+        ],
+    )
+    cur.execute(
+        "CREATE TABLE schema_index(table_name text primary key, embedding text)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def make_fdb() -> Any:
+    sqlite3.register_adapter(list, lambda l: json.dumps(l))
+
+    class CursorWrapper:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def execute(self, sql: str, params: Any = None):
+            sql = sql.replace("%s", "?")
+            sql = sql.replace("information_schema.columns", '"information_schema.columns"')
+            if params is None:
+                return self._cursor.execute(sql)
+            return self._cursor.execute(sql, params)
+
+        def fetchall(self):
+            return self._cursor.fetchall()
+
+        def close(self):
+            self._cursor.close()
+
+        def __getattr__(self, name):
+            return getattr(self._cursor, name)
+
+    class ConnWrapper:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def cursor(self):
+            return CursorWrapper(self._conn.cursor())
+
+        def commit(self):
+            self._conn.commit()
+
+        def close(self):
+            self._conn.close()
+
+    class FDBModule:
+        @staticmethod
+        def connect(dsn: str):
+            return ConnWrapper(sqlite3.connect(dsn))
+
+    return FDBModule
+
+
+def test_refresh_schema_upserts(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    setup_sqlite_db(str(db_path))
+
+    monkeypatch.setenv("DATABASE_URL", str(db_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setattr(db_schema_index, "fdb", make_fdb())
+    monkeypatch.setattr(db_schema_index, "OpenAI", lambda api_key=None: DummyOpenAI([[1.0], [2.0]]))
+
+    db_schema_index.refresh_schema()
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT table_name, embedding FROM schema_index ORDER BY table_name")
+    rows = cur.fetchall()
+    conn.close()
+
+    assert len(rows) == 2
+    assert rows[0][0] == "orders"
+    assert json.loads(rows[0][1]) == [1.0]
+    assert rows[1][0] == "users"
+    assert json.loads(rows[1][1]) == [2.0]
+
+    monkeypatch.setattr(db_schema_index, "OpenAI", lambda api_key=None: DummyOpenAI([[3.0], [4.0]]))
+    db_schema_index.refresh_schema()
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT table_name, embedding FROM schema_index ORDER BY table_name")
+    rows2 = cur.fetchall()
+    conn.close()
+
+    assert len(rows2) == 2
+    assert json.loads(rows2[0][1]) == [3.0]
+    assert json.loads(rows2[1][1]) == [4.0]


### PR DESCRIPTION
## Summary
- add a new module `db_schema_index` with `refresh_schema` to build table-level embeddings
- implement pytest covering schema indexing logic with a mocked SQLite database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e550627ec83268a7333d277e1af86