### PR TITLE
Add documentation and schema refresh utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# mac-ai
+
+A small FastAPI app that uses OpenAI to translate natural language questions in Portuguese into SQL queries for a PostgreSQL database.  The schema is embedded with pgvector so the LLM has context when generating SQL.
+
+## Running with Docker Compose
+
+1. Create an `.env` file with your OpenAI API key:
+
+```bash
+OPENAI_API_KEY=sk-...
+```
+
+2. Start the services:
+
+```bash
+docker compose up --build
+```
+
+The API will be available at `http://localhost:8000` and PostgreSQL at port `5432`.
+
+## Refreshing the Schema Index
+
+Whenever the database schema changes you should refresh the vector index used for lookup.
+
+```bash
+docker compose exec app python -m app.refresh_schema
+```
+
+This truncates and rebuilds the `schema_index` table with new embeddings.
+
+## Example Usage
+
+Ask a question via the `/perguntar` endpoint:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"pergunta": "Liste todos os registros da tabela exemplo"}' \
+  http://localhost:8000/perguntar
+```
+
+The response contains the generated SQL and the query result.
+
+## Architecture Overview
+
+```
++---------+        HTTP       +--------------+        SQL        +-----------+
+| Client  |  <--------------> |   FastAPI    |  <------------->  | Postgres  |
+| (curl)  |                   |  (mac-ai)    |                  |  +pgvector |
++---------+                   +--------------+                  +-----------+
+                                 ^        |
+                                 |        v
+                              OpenAI  Embeddings
+```
+
+1. On startup the app reads the database schema and stores embeddings in the `schema_index` table.
+2. A question is embedded and compared with `schema_index` to gather context.
+3. The LLM generates a `SELECT` statement which is executed against the database using a readonly user.
+4. Results are returned to the caller.
+

--- a/app/db.py
+++ b/app/db.py
@@ -110,3 +110,12 @@ def execute_select(conn, sql: str) -> List[Dict]:
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute(sql)
         return cur.fetchall()
+
+
+def refresh_schema(conn):
+    """Recreate embeddings for the current database schema."""
+    create_schema_index_table(conn)
+    with conn.cursor() as cur:
+        cur.execute("TRUNCATE schema_index")
+    conn.commit()
+    load_schema_embeddings(conn)

--- a/app/refresh_schema.py
+++ b/app/refresh_schema.py
@@ -1,0 +1,13 @@
+import os
+from .db import get_db_connection, refresh_schema
+
+
+def main():
+    url = os.getenv("DATABASE_URL")
+    conn = get_db_connection(url)
+    refresh_schema(conn)
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document how to run the project and its architecture
- add a helper to refresh schema embeddings

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e553407e88326a3e20032115af1f9